### PR TITLE
Update MeM_alone.m syntax to yggdrasil names

### DIFF
--- a/src/MeM_alone.m
+++ b/src/MeM_alone.m
@@ -2,10 +2,10 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Set up I/O Channels
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-in1 = CisInterface('CisInput', 'MeM_input1');
-in2 = CisInterface('CisInput', 'MeM_input2');
-in3 = CisInterface('CisInput', 'MeM_input3');
-out = CisInterface('CisOutput', 'MeM_output', '%f\n');
+in1 = YggInterface('YggInput', 'MeM_input1');
+in2 = YggInterface('YggInput', 'MeM_input2');
+in3 = YggInterface('YggInput', 'MeM_input3');
+out = YggInterface('YggOutput', 'MeM_output', '%f\n');
 disp('Done establishing I/O channels');
 
 


### PR DESCRIPTION
Yggdrasil uses different names for the interface (specifically cis is replaced with ygg)